### PR TITLE
Improve Error Handing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'daemon-kit'
 gem 'rufus-scheduler', '~> 2.0'
 gem 'safely' # Optional, but recommended.
 # gem 'toadhopper' # For reporting exceptions to hoptoad
-# gem 'mail' # For reporting exceptions via mail
+gem 'mail' # For reporting exceptions via mail
 
 group :development, :test do
   gem 'rake' # added by daemon-kit

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,9 @@ GEM
     eventmachine (1.0.7)
     i18n (0.7.0)
     json (1.8.2)
+    mail (2.6.3)
+      mime-types (>= 1.16, < 3)
+    mime-types (2.5)
     mini_portile (0.6.2)
     minitest (5.5.1)
     net-scp (1.2.1)
@@ -65,6 +68,7 @@ DEPENDENCIES
   capistrano (= 3.3.5)
   capistrano-bundler (~> 1.1)
   daemon-kit
+  mail
   nokogiri
   rake
   rspec (~> 3.2)

--- a/lib/qas/qas.rb
+++ b/lib/qas/qas.rb
@@ -4,3 +4,9 @@ require_relative 'soap_request_builder'
 require_relative 'query_with_polled_response'
 require_relative 'start_sync_poll_query'
 require_relative 'get_query_results'
+
+module PeoplesoftCourseClassData
+  module Qas
+    class SoapEnvError < StandardError; end
+  end
+end

--- a/lib/qas/start_sync_poll_query.rb
+++ b/lib/qas/start_sync_poll_query.rb
@@ -1,6 +1,9 @@
 module PeoplesoftCourseClassData
   module Qas
     class StartSyncPollQuery
+
+      class UnexpectedResponse < StandardError; end
+
       def initialize(soap_request)
         self.soap_request = soap_request
       end
@@ -17,7 +20,11 @@ module PeoplesoftCourseClassData
         xml.remove_namespaces!
         xml.at('QueryInstance').text
       rescue
-        raise PeoplesoftCourseClassData::Qas::SoapEnvError, xml.at('DefaultMessage')
+        if xml.at('Fault')
+          raise PeoplesoftCourseClassData::Qas::SoapEnvError, xml.at('DefaultMessage').text
+        else
+          raise PeoplesoftCourseClassData::Qas::StartSyncPollQuery::UnexpectedResponse, xml.to_xml
+        end
       end
     end
   end

--- a/lib/qas/start_sync_poll_query.rb
+++ b/lib/qas/start_sync_poll_query.rb
@@ -16,6 +16,8 @@ module PeoplesoftCourseClassData
       def query_instance(xml)
         xml.remove_namespaces!
         xml.at('QueryInstance').text
+      rescue
+        raise PeoplesoftCourseClassData::Qas::SoapEnvError, xml.at('DefaultMessage')
       end
     end
   end

--- a/lib/rake_runner/rake_runner.rb
+++ b/lib/rake_runner/rake_runner.rb
@@ -1,0 +1,24 @@
+require 'open3'
+
+module RakeRunner
+  class RakeRunner
+    class RakeError < StandardError; end
+
+    def run(cmd)
+      Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
+        if has_error?(stderr)
+          raise_error(stderr)
+        end
+      end
+    end
+
+    private
+    def has_error?(stderr)
+      !stderr.eof?
+    end
+
+    def raise_error(stderr)
+      raise RakeError.new(stderr.read)
+    end
+  end
+end

--- a/libexec/peoplesoft_course_class_data-daemon.rb
+++ b/libexec/peoplesoft_course_class_data-daemon.rb
@@ -36,9 +36,20 @@ end
 #end
 #
 # Example error handling (NOTE: all exceptions in scheduled tasks are logged)
-#DaemonKit::Cron.handle_exception do |job, exception|
-#  DaemonKit.logger.error "Caught exception in job #{job.job_id}: '#{exception}'"
-#end
+DaemonKit::Cron.handle_exception do |job, exception|
+  mail         = ::Mail.new
+  mail.from    = 'asrweb@umn.edu'
+  mail.to      = 'ASR-WEB-ERRORS@lists.umn.edu'
+  mail.subject = "Peoplesoft Course Class Data [#{ENV['DAEMON_ENV']}] - Exception"
+
+  mail.body = <<-EOF
+    An exception occured, details below:
+    Type: #{exception.class.name}
+    Message: #{exception.message}
+    EOF
+
+  mail.deliver
+end
 
 DaemonKit::Cron.scheduler.cron "0 23 * * 0-6" do
   path = "#{PeoplesoftCourseClassData::Config::FILE_ROOT}"

--- a/libexec/peoplesoft_course_class_data-daemon.rb
+++ b/libexec/peoplesoft_course_class_data-daemon.rb
@@ -43,8 +43,9 @@ end
 DaemonKit::Cron.scheduler.cron "0 23 * * 0-6" do
   path = "#{PeoplesoftCourseClassData::Config::FILE_ROOT}"
   env = PeoplesoftCourseClassData::Config::PS_ENV
-  sh "bundle exec rake -f #{path}/tasks/peoplesoft_course_class_data.rake peoplesoft_course_class_data:download['#{env}','#{path}/tmp']"
-  sh "bundle exec rake -f #{path}/tasks/peoplesoft_course_class_data.rake peoplesoft_course_class_data:copy_good_files['#{path}/tmp','#{path}/json_tmp']"
+  runner = ::RakeRunner::RakeRunner.new
+  runner.run "bundle exec rake -f #{path}/tasks/peoplesoft_course_class_data.rake peoplesoft_course_class_data:download['#{env}','#{path}/tmp']"
+  runner.run "bundle exec rake -f #{path}/tasks/peoplesoft_course_class_data.rake peoplesoft_course_class_data:copy_good_files['#{path}/tmp','#{path}/json_tmp']"
 end
 
 

--- a/spec/fixtures/rake_runner_test_tasks.rake
+++ b/spec/fixtures/rake_runner_test_tasks.rake
@@ -1,0 +1,10 @@
+require 'rake'
+namespace :rake_runner_test_tasks do
+  task :raise_error do |t|
+    raise "error occurred"
+  end
+
+  task :success do |t|
+    puts "hooray"
+  end
+end

--- a/spec/lib/qas/start_sync_poll_query_spec.rb
+++ b/spec/lib/qas/start_sync_poll_query_spec.rb
@@ -36,6 +36,23 @@ RSpec.describe PeoplesoftCourseClassData::Qas::StartSyncPollQuery do
           expect{ subject.run(payload) }.to raise_error(/User password failed/)
         end
       end
+
+      context "some other goofy reponse" do
+        before do
+          response = Nokogiri.XML("<weirdness>Error!</weirdness>") do |config|
+                        config.default_xml.noblanks
+                      end
+          allow(soap_request_double).to receive(:execute_request) { response }
+        end
+
+        it "raises an UnexpectedResponse error" do
+          expect{ subject.run(payload) }.to raise_error(PeoplesoftCourseClassData::Qas::StartSyncPollQuery::UnexpectedResponse)
+        end
+
+        it "has the xml as the error message" do
+          expect{ subject.run(payload) }.to raise_error(/<weirdness>Error!<\/weirdness>/)
+        end
+      end
     end
   end
 

--- a/spec/lib/qas/start_sync_poll_query_spec.rb
+++ b/spec/lib/qas/start_sync_poll_query_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../../lib/qas/start_sync_poll_query'
+require_relative '../../../lib/qas/qas'
 require          'nokogiri'
 
 RSpec.describe PeoplesoftCourseClassData::Qas::StartSyncPollQuery do
@@ -21,6 +21,22 @@ RSpec.describe PeoplesoftCourseClassData::Qas::StartSyncPollQuery do
 
       expect(subject.run(payload)).to eq(query_instance)
     end
+
+    context "errors" do
+      context "SOAP-ENV:Fault" do
+        before do
+          allow(soap_request_double).to receive(:execute_request) { soap_error_response }
+        end
+
+        it "raises a SoapEnvError" do
+          expect{ subject.run(payload) }.to raise_error(PeoplesoftCourseClassData::Qas::SoapEnvError)
+        end
+
+        it "has the Default Message as the text" do
+          expect{ subject.run(payload) }.to raise_error(/User password failed/)
+        end
+      end
+    end
   end
 
   def sync_poll_response(query_instance)
@@ -38,6 +54,35 @@ RSpec.describe PeoplesoftCourseClassData::Qas::StartSyncPollQuery do
                     </soapenv:Body>
                   </soapenv:Envelope>
                RESPONSE
+    response = Nokogiri.XML(response) do |config|
+      config.default_xml.noblanks
+    end
+    response
+  end
+
+  def soap_error_response
+    response = <<-RESPONSE
+                <?xml version="1.0"?>
+                <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+                  <SOAP-ENV:Body>
+                    <SOAP-ENV:Fault>
+                      <faultcode>SOAP-ENV:Server</faultcode>
+                      <faultstring>null</faultstring>
+                      <detail>
+                        <IBResponse xmlns="" type="error">
+                          <DefaultTitle>Integration Broker Response</DefaultTitle>
+                          <StatusCode>20</StatusCode>
+                          <MessageID>45</MessageID>
+                          <DefaultMessage><![CDATA[User password failed. (158,45)]]></DefaultMessage>
+                          <MessageParameters>
+                            <Parameter><![CDATA[ANONYMOUS]]></Parameter>
+                          </MessageParameters>
+                        </IBResponse>
+                      </detail>
+                    </SOAP-ENV:Fault>
+                  </SOAP-ENV:Body>
+                </SOAP-ENV:Envelope>
+            RESPONSE
     response = Nokogiri.XML(response) do |config|
       config.default_xml.noblanks
     end

--- a/spec/lib/rake_runner/rake_runner_spec.rb
+++ b/spec/lib/rake_runner/rake_runner_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../../lib/rake_runner/rake_runner'
+
+RSpec.describe RakeRunner::RakeRunner do
+
+  subject { described_class.new }
+
+  let(:rake_file) { File.expand_path('../../../fixtures/rake_runner_test_tasks.rake',  __FILE__) }
+
+  describe "run" do
+    it "raises errors when then task fails" do
+      cmd = "bundle exec rake -f #{rake_file} rake_runner_test_tasks:raise_error"
+      expect { subject.run(cmd) }.to raise_error(RakeRunner::RakeRunner::RakeError, /error occurred/)
+    end
+
+    it "does not raise errors when the task succeeds" do
+      cmd = "bundle exec rake -f #{rake_file} rake_runner_test_tasks:success"
+      subject.run(cmd)
+    end
+  end
+
+end


### PR DESCRIPTION
This pull request has a couple of improvements to our error handing

1.Add more descriptive errors for things that can go wrong when we initiate a query via integration broker. 

When a integration broker query request is started, we expect to get a query instance back. The code that handled the response was fairly naive; it just looked for that node, found the text and then handed that instance identifier off to the process that polls for the data. If there was a problem (say bad credentials), we would still get a response but it would not contain the query instance node and we get (non-descriptive) NoMethodError when we try to get the text from nil node. 

Usually if something goes wrong with setting up the request, we get a SOAP-ENV:Fault response that has more description of what went wrong. 8a5b27d and 9915f15 try to use the information in the Fault to raise a more descriptive error.

2.Raise daemon kit errors

The daemon is running rake tasks to do its work. When rake encounters exceptions, it sends them to stderr so the daemon does not know what went wrong, just that the process returned with 1 (and sometimes not even that depending on how the process was spawned). f715880 works around this by adding a class to run these commands via something that has access to stderr and can raise an exception if stderr has content. 5c3870a and 8db53f1 configures the daemon to send mail notifications if an exception is encountered.
