### PR TITLE
Dl/integration test for null node output

### DIFF
--- a/spec/fixtures/no_grading_basis.xml
+++ b/spec/fixtures/no_grading_basis.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Body>
+    <QAS_GETQUERYRESULTS_RESP_MSG xmlns="http://xmlns.oracle.com/Enterprise/Tools/schemas/QAS_GETQUERYRESULTS_RESP_MSG.VERSION_2">
+      <query xmlns="http://xmlns.oracle.com/Enterprise/Tools/schemas/QAS_QUERYRESULTS_XMLP_RESP.VERSION_1" numrows="1816" queryname="UM_SR003_0021_CLASS_DATA">
+        <row rownumber="520">
+          <A.INSTITUTION><![CDATA[UMNTC]]></A.INSTITUTION>
+          <A.CAMPUS><![CDATA[UMNTC]]></A.CAMPUS>
+          <A.STRM><![CDATA[1149]]></A.STRM>
+          <A.SESSION_CODE><![CDATA[001]]></A.SESSION_CODE>
+          <A.SUBJECT><![CDATA[AFRO]]></A.SUBJECT>
+          <A.DESCR><![CDATA[African Amer & African Studies]]></A.DESCR>
+          <A.CATALOG_NBR><![CDATA[3120]]></A.CATALOG_NBR>
+          <A.CLASS_SECTION><![CDATA[001]]></A.CLASS_SECTION>
+          <A.SSR_COMPONENT><![CDATA[LEC]]></A.SSR_COMPONENT>
+          <A.DESCR1><![CDATA[Soc Mvts in African Diaspora]]></A.DESCR1>
+          <A.CLASS_STAT><![CDATA[A]]></A.CLASS_STAT>
+          <A.LOCATION><![CDATA[TCWESTBANK]]></A.LOCATION>
+          <A.INSTRUCTION_MODE><![CDATA[P]]></A.INSTRUCTION_MODE>
+          <A.DESCR2><![CDATA[In Person Term Based]]></A.DESCR2>
+          <A.ENRL_CAP>25</A.ENRL_CAP>
+          <A.ENRL_TOT>24</A.ENRL_TOT>
+          <A.UNITS_MINIMUM>3</A.UNITS_MINIMUM>
+          <A.UNITS_MAXIMUM>3</A.UNITS_MAXIMUM>
+          <A.GRADING_BASIS/>
+          <A.XLATLONGNAME/>
+          <A.CRS_TOPIC_ID>0</A.CRS_TOPIC_ID>
+          <A.DESCRFORMAL/>
+          <A.SCHEDULE_PRINT><![CDATA[Y]]></A.SCHEDULE_PRINT>
+          <A.EQUIV_CRSE_ID><![CDATA[00788]]></A.EQUIV_CRSE_ID>
+          <A.CRSE_REPEATABLE><![CDATA[N]]></A.CRSE_REPEATABLE>
+          <A.UNITS_REPEAT_LIMIT>3</A.UNITS_REPEAT_LIMIT>
+          <A.CRSE_REPEAT_LIMIT>1</A.CRSE_REPEAT_LIMIT>
+          <A.CLASS_MTG_NBR>1</A.CLASS_MTG_NBR>
+          <A.FACILITY_ID><![CDATA[BLEGH00155]]></A.FACILITY_ID>
+          <A.MEETING_TIME_START>13:00</A.MEETING_TIME_START>
+          <A.MEETING_TIME_END>14:15</A.MEETING_TIME_END>
+          <A.MON/>
+          <A.TUES><![CDATA[T]]></A.TUES>
+          <A.WED/>
+          <A.UM_THURS><![CDATA[TH]]></A.UM_THURS>
+          <A.FRI/>
+          <A.SAT/>
+          <A.UM_SUNDAY/>
+          <A.START_DT>2014-09-02</A.START_DT>
+          <A.END_DT>2014-12-10</A.END_DT>
+          <A.INSTR_ASSIGN_SEQ>1</A.INSTR_ASSIGN_SEQ>
+          <A.EMPLID><![CDATA[0000000]]></A.EMPLID>
+          <A.INSTR_ROLE><![CDATA[PI]]></A.INSTR_ROLE>
+          <A.SCHED_PRINT_INSTR><![CDATA[Y]]></A.SCHED_PRINT_INSTR>
+          <A.CRSE_ATTR/>
+          <A.CRSE_ATTR_VALUE/>
+          <A.START_DT_CHN/>
+          <A.END_DT_AFT/>
+          <A.UM_ENRL_CAP2>0</A.UM_ENRL_CAP2>
+          <A.RQRMNT_GROUP/>
+          <A.CLASS_NOTES_SEQ>0</A.CLASS_NOTES_SEQ>
+          <A.DESCR3><![CDATA[Blegen Hall 155]]></A.DESCR3>
+          <EXPR67_67/>
+          <A.NAME_DISPLAY><![CDATA[Yuichiro Onishi]]></A.NAME_DISPLAY>
+          <A.EMAIL_ADDR><![CDATA[remove@umn.edu]]></A.EMAIL_ADDR>
+          <EXPR1_1><![CDATA[Political, cultural, historical linkages between Africans, African-Americans, African-Caribbean. Black socio-political movements/radical intellectual trends in late 19th/20th centuries. Colonialism/racism. Protest organizations, radical movements in United States/Europe.]]></EXPR1_1>
+          <A.SUBJECT_SRCH><![CDATA[AFRO]]></A.SUBJECT_SRCH>
+          <A.CATALOG_NBR_SRCH><![CDATA[5120]]></A.CATALOG_NBR_SRCH>
+          <A.UM_CRSE_ATTR><![CDATA[CLE]]></A.UM_CRSE_ATTR>
+          <A.UM_CRSE_ATT_VAL><![CDATA[GP]]></A.UM_CRSE_ATT_VAL>
+          <A.DESCR50><![CDATA[Global Perspectives]]></A.DESCR50>
+          <A.COMBINED_SECTION><![CDATA[C]]></A.COMBINED_SECTION>
+          <A.CLASS_NBR_CMBND>26192</A.CLASS_NBR_CMBND>
+          <A.SUBJECT_SRCH1><![CDATA[AFRO]]></A.SUBJECT_SRCH1>
+          <A.CATALOG_NBR_SRCH1><![CDATA[5120]]></A.CATALOG_NBR_SRCH1>
+          <A.UM_CLASS_SECTION><![CDATA[001]]></A.UM_CLASS_SECTION>
+          <A.CRSE_ID><![CDATA[795342]]></A.CRSE_ID>
+          <A.CLASS_NBR>26191</A.CLASS_NBR>
+          <A.CLASS_TYPE><![CDATA[E]]></A.CLASS_TYPE>
+          <A.DESCRSHORT><![CDATA[BlegH 155]]></A.DESCRSHORT>
+        </row>
+      </query>
+      <QAS_QUERYRESULTS_STATUS_RESP xmlns="http://xmlns.oracle.com/Enterprise/Tools/schemas/QAS_QUERYRESULTS_STATUS_RESP.VERSION_2">
+        <status>blockRetrieved</status>
+      </QAS_QUERYRESULTS_STATUS_RESP>
+    </QAS_GETQUERYRESULTS_RESP_MSG>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/spec/fixtures/no_instruction_mode.xml
+++ b/spec/fixtures/no_instruction_mode.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Body>
+    <QAS_GETQUERYRESULTS_RESP_MSG xmlns="http://xmlns.oracle.com/Enterprise/Tools/schemas/QAS_GETQUERYRESULTS_RESP_MSG.VERSION_2">
+      <query xmlns="http://xmlns.oracle.com/Enterprise/Tools/schemas/QAS_QUERYRESULTS_XMLP_RESP.VERSION_1" numrows="1816" queryname="UM_SR003_0021_CLASS_DATA">
+        <row rownumber="39605">
+          <A.INSTITUTION><![CDATA[UMNTC]]></A.INSTITUTION>
+          <A.CAMPUS><![CDATA[UMNTC]]></A.CAMPUS>
+          <A.STRM><![CDATA[1149]]></A.STRM>
+          <A.SESSION_CODE><![CDATA[001]]></A.SESSION_CODE>
+          <A.SUBJECT><![CDATA[PHYS]]></A.SUBJECT>
+          <A.DESCR><![CDATA[Physics]]></A.DESCR>
+          <A.CATALOG_NBR><![CDATA[1101W]]></A.CATALOG_NBR>
+          <A.CLASS_SECTION><![CDATA[103]]></A.CLASS_SECTION>
+          <A.SSR_COMPONENT><![CDATA[LAB]]></A.SSR_COMPONENT>
+          <A.DESCR1><![CDATA[Intro College Phys I]]></A.DESCR1>
+          <A.CLASS_STAT><![CDATA[A]]></A.CLASS_STAT>
+          <A.LOCATION><![CDATA[TCEASTBANK]]></A.LOCATION>
+          <A.INSTRUCTION_MODE/>
+          <A.DESCR2/>
+          <A.ENRL_CAP>18</A.ENRL_CAP>
+          <A.ENRL_TOT>18</A.ENRL_TOT>
+          <A.UNITS_MINIMUM>4</A.UNITS_MINIMUM>
+          <A.UNITS_MAXIMUM>4</A.UNITS_MAXIMUM>
+          <A.GRADING_BASIS><![CDATA[OPT]]></A.GRADING_BASIS>
+          <A.XLATLONGNAME><![CDATA[Student Option]]></A.XLATLONGNAME>
+          <A.CRS_TOPIC_ID>0</A.CRS_TOPIC_ID>
+          <A.DESCRFORMAL/>
+          <A.SCHEDULE_PRINT><![CDATA[Y]]></A.SCHEDULE_PRINT>
+          <A.EQUIV_CRSE_ID/>
+          <A.CRSE_REPEATABLE><![CDATA[N]]></A.CRSE_REPEATABLE>
+          <A.UNITS_REPEAT_LIMIT>4</A.UNITS_REPEAT_LIMIT>
+          <A.CRSE_REPEAT_LIMIT>1</A.CRSE_REPEAT_LIMIT>
+          <A.CLASS_MTG_NBR>1</A.CLASS_MTG_NBR>
+          <A.FACILITY_ID><![CDATA[PHYS000130]]></A.FACILITY_ID>
+          <A.MEETING_TIME_START>16:40</A.MEETING_TIME_START>
+          <A.MEETING_TIME_END>18:35</A.MEETING_TIME_END>
+          <A.MON><![CDATA[M]]></A.MON>
+          <A.TUES/>
+          <A.WED/>
+          <A.UM_THURS/>
+          <A.FRI/>
+          <A.SAT/>
+          <A.UM_SUNDAY/>
+          <A.START_DT>2014-09-02</A.START_DT>
+          <A.END_DT>2014-12-10</A.END_DT>
+          <A.INSTR_ASSIGN_SEQ>4</A.INSTR_ASSIGN_SEQ>
+          <A.EMPLID><![CDATA[0000000]]></A.EMPLID>
+          <A.INSTR_ROLE><![CDATA[PI]]></A.INSTR_ROLE>
+          <A.SCHED_PRINT_INSTR><![CDATA[N]]></A.SCHED_PRINT_INSTR>
+          <A.CRSE_ATTR/>
+          <A.CRSE_ATTR_VALUE/>
+          <A.START_DT_CHN/>
+          <A.END_DT_AFT/>
+          <A.UM_ENRL_CAP2>0</A.UM_ENRL_CAP2>
+          <A.RQRMNT_GROUP/>
+          <A.CLASS_NOTES_SEQ>0</A.CLASS_NOTES_SEQ>
+          <A.DESCR3><![CDATA[Tate Laboratory 130]]></A.DESCR3>
+          <EXPR67_67/>
+          <A.NAME_DISPLAY><![CDATA[Vincent Noireaux]]></A.NAME_DISPLAY>
+          <A.EMAIL_ADDR><![CDATA[remove@umn.edu]]></A.EMAIL_ADDR>
+          <EXPR1_1><![CDATA[Fundamental principles of physics in the context of everyday world. Use of kinematics/dynamics principles and quantitative/qualitative problem solving techniques to understand natural phenomena. Lecture, recitation, lab.]]></EXPR1_1>
+          <A.SUBJECT_SRCH/>
+          <A.CATALOG_NBR_SRCH/>
+          <A.UM_CRSE_ATTR><![CDATA[CLE]]></A.UM_CRSE_ATTR>
+          <A.UM_CRSE_ATT_VAL><![CDATA[WI]]></A.UM_CRSE_ATT_VAL>
+          <A.DESCR50><![CDATA[Writing Intensive]]></A.DESCR50>
+          <A.COMBINED_SECTION/>
+          <A.CLASS_NBR_CMBND>0</A.CLASS_NBR_CMBND>
+          <A.SUBJECT_SRCH1/>
+          <A.CATALOG_NBR_SRCH1/>
+          <A.UM_CLASS_SECTION/>
+          <A.CRSE_ID><![CDATA[002066]]></A.CRSE_ID>
+          <A.CLASS_NBR>10788</A.CLASS_NBR>
+          <A.CLASS_TYPE><![CDATA[E]]></A.CLASS_TYPE>
+          <A.DESCRSHORT><![CDATA[Phys 130]]></A.DESCRSHORT>
+        </row>
+      </query>
+      <QAS_QUERYRESULTS_STATUS_RESP xmlns="http://xmlns.oracle.com/Enterprise/Tools/schemas/QAS_QUERYRESULTS_STATUS_RESP.VERSION_2">
+        <status>blockRetrieved</status>
+      </QAS_QUERYRESULTS_STATUS_RESP>
+    </QAS_GETQUERYRESULTS_RESP_MSG>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/spec/lib/xml_parser/class_json_spec.rb
+++ b/spec/lib/xml_parser/class_json_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe PeoplesoftCourseClassData::XmlParser::ClassJson do
     `cp #{fixture_directory}/reference.xml #{working_directory}/#{file_name.xml}`
   end
 
+  after do
+    `rm #{working_directory}/*`
+  end
+
   subject { described_class.new("#{working_directory}/#{file_name.xml}") }
 
   describe "to_file" do

--- a/spec/lib/xml_parser/class_json_spec.rb
+++ b/spec/lib/xml_parser/class_json_spec.rb
@@ -36,6 +36,40 @@ RSpec.describe PeoplesoftCourseClassData::XmlParser::ClassJson do
 
       expect(actual_json).to eq(expected_json)
     end
+
+    context "when the xml has no data for a sub resources" do
+      context "example 1 - grading basis" do
+        before do
+          `cp #{fixture_directory}/no_grading_basis.xml #{working_directory}/#{file_name.xml}`
+        end
+
+        it "does not build the grading basis attribute" do
+          subject.to_file
+
+          json = JSON.parse(File.read("#{working_directory}/#{file_name.json}"))
+          section_keys = json["courses"].flat_map { |course| course["sections"] }.flat_map(&:keys).uniq
+
+          expect(section_keys).not_to be_empty
+          expect(section_keys).not_to include("grading_basis")
+        end
+      end
+
+      context "example 2 - instruction mode" do
+        before do
+          `cp #{fixture_directory}/no_instruction_mode.xml #{working_directory}/#{file_name.xml}`
+        end
+
+        it "does not build the instruction mode attribute" do
+          subject.to_file
+
+          json = JSON.parse(File.read("#{working_directory}/#{file_name.json}"))
+          section_keys = json["courses"].flat_map { |course| course["sections"] }.flat_map(&:keys).uniq
+
+          expect(section_keys).not_to be_empty
+          expect(section_keys).not_to include("instruction_mode")
+        end
+      end
+    end
   end
 
   def sorted_class_data!(class_data)


### PR DESCRIPTION
when the xml has no information for a subresource that node should be missing from the json. This was previously tested at a unit level in resource_spec.rb. This commit adds xml file to json file integration
tests for this behavior.

no_grading_basis.xml and no_instruction_mode.xml are subsets of our reference.xml with data removed. The tests make sure the key for the missing resource is missing from the parsed json.