### PR TITLE
change RakeRunner#run to work with Rake#sh

### DIFF
--- a/lib/rake_runner/rake_runner.rb
+++ b/lib/rake_runner/rake_runner.rb
@@ -6,15 +6,16 @@ module RakeRunner
 
     def run(cmd)
       Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
-        if has_error?(stderr)
+        if has_error?(stderr, wait_thr)
           raise_error(stderr)
         end
       end
     end
 
     private
-    def has_error?(stderr)
-      !stderr.eof?
+    def has_error?(stderr, wait_thr)
+      wait_thr.value != 0 &&
+        !stderr.eof?
     end
 
     def raise_error(stderr)

--- a/spec/fixtures/rake_runner_test_tasks.rake
+++ b/spec/fixtures/rake_runner_test_tasks.rake
@@ -7,4 +7,8 @@ namespace :rake_runner_test_tasks do
   task :success do |t|
     puts "hooray"
   end
+
+  task :sh_success do |t|
+    sh "echo hooray"
+  end
 end

--- a/spec/lib/rake_runner/rake_runner_spec.rb
+++ b/spec/lib/rake_runner/rake_runner_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe RakeRunner::RakeRunner do
       cmd = "bundle exec rake -f #{rake_file} rake_runner_test_tasks:success"
       subject.run(cmd)
     end
+
+    it "does not raise errors even with Rake#sh's goofy use of sterr" do
+      cmd = "bundle exec rake -f #{rake_file} rake_runner_test_tasks:sh_success"
+      subject.run(cmd)
+    end
   end
 
 end


### PR DESCRIPTION
By default `Rake#sh` sends the command to stderr before running it (see `Rake#rake_output_message`). Any output to stderr will cause RakeRunner to raise an exception, so any rake tasks that used sh would cause an exception.

Change the implementation of `RakeRunner#run` to check for the return value of the command in addition to the contents of stderr. This prevents rake_output_message's use of stderr from causing false exceptions to be raised on tasks that succeed.