### PR TITLE
Extract Grouping logic from SortData workflow step

### DIFF
--- a/lib/grouping.rb
+++ b/lib/grouping.rb
@@ -1,0 +1,21 @@
+module PeoplesoftCourseClassData
+  class Grouping
+    def self.group(collections)
+      new(collections)
+    end
+
+    def initialize(*collections)
+      self.items = collections.flatten
+    end
+
+    def by(attribute)
+      group_values = items.map(&attribute).uniq
+      group_values.map do |group_value|
+        items.select { |item| item.send(attribute) == group_value }
+      end
+    end
+
+    private
+    attr_accessor :items
+  end
+end

--- a/lib/workflow/sort_data.rb
+++ b/lib/workflow/sort_data.rb
@@ -1,12 +1,8 @@
 module PeoplesoftCourseClassData
   class SortData
     def self.run(parsed_data, orchestrator)
-      all_course_aspects  = parsed_data.flatten
-      course_ids          = all_course_aspects.map(&:course_id).uniq.sort
-      sorted_data         = course_ids.map do |course_id|
-                              all_course_aspects.select { |course_aspect| course_aspect.course_id == course_id }
-                            end
-      orchestrator.run_step(MergeData, sorted_data)
+      results = Grouping.group(parsed_data).by(:course_id)
+      orchestrator.run_step(MergeData, results)
     end
   end
 end

--- a/spec/lib/grouping_spec.rb
+++ b/spec/lib/grouping_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe PeoplesoftCourseClassData::Grouping do
+  let(:values)           { (10..99).to_a.take(rand(3..7)) }
+  let(:collections)   do
+                        number_of_collections = rand(3..6)
+                        number_of_collections.times.map do
+                          10.times.map { OpenStruct.new(some_attribute: values.sample) }
+                        end
+                      end
+
+  subject { described_class.new(*collections) }
+
+  describe "#by" do
+    it "returns an enumerable" do
+      expect(subject.by(:some_attribute)).to respond_to(:each)
+    end
+
+    it "contains enumerables" do
+      subject.by(:some_attribute).each do |group|
+        expect(group).to respond_to(:each)
+      end
+    end
+
+    it "has a collection for each unique value of the supplied attribute" do
+      number_of_groupings = collections.flatten.map { |item| item.send(:some_attribute) }.uniq.count
+      expect(subject.by(:some_attribute).count).to eq(number_of_groupings)
+    end
+
+    it "all members of the collection share that value" do
+      subject.by(:some_attribute).each do |grouped_collection|
+        expect(grouped_collection.map(&:some_attribute).uniq.count).to eq(1)
+      end
+    end
+
+    it "values are not shared across collections" do
+      all_values = subject.by(:some_attribute).map { |sub_collection| sub_collection.first.some_attribute }
+      unique_values = subject.by(:some_attribute).map { |sub_collection| sub_collection.first.some_attribute }.uniq
+      expect(all_values).to eq(unique_values)
+    end
+  end
+
+  describe ".group" do
+    it "builds a new Grouping with the supplied collections" do
+      expect(described_class).to receive(:new).with(collections)
+      described_class.group(collections)
+    end
+  end
+end

--- a/spec/lib/sort_data_spec.rb
+++ b/spec/lib/sort_data_spec.rb
@@ -6,17 +6,16 @@ RSpec.describe PeoplesoftCourseClassData::SortData do
       course_ids = (1..rand(3..5)).to_a
       class_data = 10.times.map { |i| PeoplesoftCourseClassData::XmlParser::CourseAspect.new(course_id: course_ids.sample, catalog_number: "class_catalog_#{i}") }
       course_data = 10.times.map { |i| PeoplesoftCourseClassData::XmlParser::CourseAspect.new(course_id: course_ids.sample, catalog_number: "course_catalog_#{i}") }
+      parsed_data = [class_data, course_data]
 
-      expected = course_ids.map do |id|
-        matched_course_aspects = class_data.select{ |course_aspect| course_aspect.course_id == id}
-        matched_course_aspects << course_data.select{ |course_aspect| course_aspect.course_id == id}
-        matched_course_aspects.flatten
-      end
+      expected = Array.new
 
-      expected.reject! { |course_collection| course_collection.empty? }
+      grouping = instance_double("PeoplesoftCourseClassData::Grouping")
+      allow(PeoplesoftCourseClassData::Grouping).to receive(:group).with(parsed_data).and_return(grouping)
+      allow(grouping).to receive(:by).with(:course_id).and_return(expected)
 
       expect(orchestrator).to receive(:run_step).with(PeoplesoftCourseClassData::MergeData, expected)
-      described_class.run([class_data, course_data], orchestrator)
+      described_class.run(parsed_data, orchestrator)
     end
   end
 end


### PR DESCRIPTION
The tests for `SortData` were a little hacky because we could not make fine grained assertions about the results that were getting passed on to `MergeData`. Specifically there were ordering issues that we  worked around by specifying an additional, not strictly necessary sort in our implementation.

To address this issue more directly, 36f55c8 extracts the processing work of the `SortData` step - taking the collections of `CourseAspects` from the `ClassService` and `CourseService` and returning a collection that contains the items gathered by course_id - into a `Grouping` class that can be tested more directly.

ddebceb then re-implements `SortData` to use `Grouping` to produce the results that are sent on to `MergeData`. 