### PR TITLE
Extract enrollment_cap from XML into JSON

### DIFF
--- a/lib/xml_parser/class_row.rb
+++ b/lib/xml_parser/class_row.rb
@@ -26,6 +26,9 @@ module PeoplesoftCourseClassData
         course__section__instruction_mode__description: {
           xml_field:  'A.DESCR2'
         },
+        course__section__enrollment_cap: {
+          xml_field:  'A.ENRL_CAP'
+        },
         course__section__instructor__name: {
           xml_field:  'A.NAME_DISPLAY'
         },

--- a/lib/xml_parser/section.rb
+++ b/lib/xml_parser/section.rb
@@ -2,7 +2,7 @@ module PeoplesoftCourseClassData
   module XmlParser
     class Section < Resource
       def self.attributes
-        [:class_number, :number, :component, :location, :notes, :instruction_mode]
+        [:class_number, :number, :component, :location, :notes, :enrollment_cap, :instruction_mode]
       end
 
       def self.child_collections

--- a/spec/fixtures/reference_combined.json
+++ b/spec/fixtures/reference_combined.json
@@ -52,6 +52,7 @@
           "component": "LEC",
           "location": "TCEASTBANK",
           "notes": "3-hr common final exam",
+          "enrollment_cap": "250",
           "instruction_mode": {
             "type": "instruction_mode",
             "instruction_mode_id": "P",
@@ -111,6 +112,7 @@
           "component": "DIS",
           "location": "TCEASTBANK",
           "notes": "",
+          "enrollment_cap": "21",
           "instruction_mode": {
             "type": "instruction_mode",
             "instruction_mode_id": "P",
@@ -160,6 +162,7 @@
           "component": "LAB",
           "location": "TCEASTBANK",
           "notes": "",
+          "enrollment_cap": "18",
           "instruction_mode": {
             "type": "instruction_mode",
             "instruction_mode_id": "P",
@@ -215,6 +218,7 @@
           "component": "DIS",
           "location": "TCEASTBANK",
           "notes": "",
+          "enrollment_cap": "21",
           "instruction_mode": {
             "type": "instruction_mode",
             "instruction_mode_id": "P",
@@ -264,6 +268,7 @@
           "component": "LAB",
           "location": "TCEASTBANK",
           "notes": "",
+          "enrollment_cap": "18",
           "instruction_mode": {
             "type": "instruction_mode",
             "instruction_mode_id": "P",
@@ -319,6 +324,7 @@
           "component": "DIS",
           "location": "TCEASTBANK",
           "notes": "",
+          "enrollment_cap": "21",
           "instruction_mode": {
             "type": "instruction_mode",
             "instruction_mode_id": "P",
@@ -368,6 +374,7 @@
           "component": "LAB",
           "location": "TCEASTBANK",
           "notes": "",
+          "enrollment_cap": "18",
           "instruction_mode": {
             "type": "instruction_mode",
             "instruction_mode_id": "P",
@@ -423,6 +430,7 @@
           "component": "DIS",
           "location": "TCEASTBANK",
           "notes": "",
+          "enrollment_cap": "21",
           "instruction_mode": {
             "type": "instruction_mode",
             "instruction_mode_id": "P",
@@ -472,6 +480,7 @@
           "component": "LAB",
           "location": "TCEASTBANK",
           "notes": "",
+          "enrollment_cap": "18",
           "instruction_mode": {
             "type": "instruction_mode",
             "instruction_mode_id": "P",
@@ -568,6 +577,7 @@
           "component": "LEC",
           "location": "TCWESTBANK",
           "notes": "",
+          "enrollment_cap": "25",
           "instruction_mode": {
             "type": "instruction_mode",
             "instruction_mode_id": "P",


### PR DESCRIPTION
This change was requested by UMMMO. They use the Class Schedule PDF to
generate their own version of a Class SChedule PDF that includes
enrollment cap data.