### PR TITLE
Add rake as all-environment dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'nokogiri'
 gem 'activesupport', '~> 4.2.0'
 gem 'daemon-kit'
+gem 'rake'
 
 # daemon-kit changes
 gem 'rufus-scheduler', '~> 2.0'
@@ -11,7 +12,6 @@ gem 'safely' # Optional, but recommended.
 gem 'mail' # For reporting exceptions via mail
 
 group :development, :test do
-  gem 'rake' # added by daemon-kit
   gem 'rspec', '~> 3.2'
 end
 


### PR DESCRIPTION
In a newly-built server with Ruby 2.3.3 rake was not available in a
`bundle exec` context. Since this daemon requires rake we should declare
it as a dependency