### PR TITLE
Use qat on staging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       eventmachine (>= 0.12.10)
       thor
     diff-lcs (1.2.5)
-    eventmachine (1.0.7)
+    eventmachine (1.2.5)
     i18n (0.7.0)
     json (1.8.3)
     mail (2.6.3)
@@ -74,4 +74,4 @@ DEPENDENCIES
   safely
 
 BUNDLED WITH
-   1.11.2
+   1.15.1

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -5,6 +5,6 @@
 #config.log_level = :debug
 module ::PeoplesoftCourseClassData
   module Config
-    PS_ENV = 'prd'
+    PS_ENV = 'qat'
   end
 end


### PR DESCRIPTION
For some reason we are currently pointing to the production endpoint in
our staging environment. For testing of PeopleSoft 9.2, we need to point
to the qat endpoint. Going forward, it makes more sense to continue to
point to the qat endpoint.

Also, we needed to update the eventmachine gem in order to get bundler to install the gem.