### PR TITLE
Update terms, from Spring 2019 to Fall 2019

### DIFF
--- a/config/query_parameters.rb
+++ b/config/query_parameters.rb
@@ -23,9 +23,9 @@ module PeoplesoftCourseClassData
                 }
               ]
     TERMS = [
-      {term: '1185'},
-      {term: '1189'},
       {term: '1193'},
+      {term: '1195'},
+      {term: '1199'},
     ]
 
     QUERY_PARAMETERS = CAMPUSES.inject([]) do |array, campus|


### PR DESCRIPTION
Domini asked for the Fall '19 course catalog for Morris in [INC2121297](http://sn.umn.edu/INC2121297).

When I was trying to build it, I noticed the course service wasn't
returning term data for Fall 2019 (1199), so this commit updates the
query to grab the next 3 terms.