### PR TITLE
Update for PeopleTools 8.56

### DIFF
--- a/lib/qas/soap_request.rb
+++ b/lib/qas/soap_request.rb
@@ -41,7 +41,7 @@ module PeoplesoftCourseClassData
           <wsse:Security soap:mustUnderstand="1" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
             <wsse:UsernameToken>
               <wsse:Username>#{credentials.username}</wsse:Username>
-              <wsse:Password>#{credentials.password}</wsse:Password>
+              <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">#{credentials.password}</wsse:Password>
             </wsse:UsernameToken>
           </wsse:Security>
         </soapenv:Header>

--- a/spec/lib/qas/soap_request_spec.rb
+++ b/spec/lib/qas/soap_request_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe PeoplesoftCourseClassData::Qas::SoapRequest do
           <wsse:Security soap:mustUnderstand="1" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
             <wsse:UsernameToken>
               <wsse:Username>#{credentials.username}</wsse:Username>
-              <wsse:Password>#{credentials.password}</wsse:Password>
+              <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">#{credentials.password}</wsse:Password>
             </wsse:UsernameToken>
           </wsse:Security>
         </soapenv:Header>


### PR DESCRIPTION
This updates SOAP requests to work with the change to Integration Broker that
comes with PeopleTools 8.56

Per OIT

> WSSE authentication headers in SOAP messages sent to PeopleSoft
> Integration Broker now require a Password Type
> attribute.

This attribute also works with older versions of PeopleTools, so it can
be deployed before the new version of PeopleTools is released.