### PR TITLE
Remove Fall 2019

### DIFF
--- a/config/query_parameters.rb
+++ b/config/query_parameters.rb
@@ -23,7 +23,6 @@ module PeoplesoftCourseClassData
                 }
               ]
     TERMS = [
-      {term: '1199'},
       {term: '1203'},
       {term: '1205'},
       {term: '1209'},


### PR DESCRIPTION
In #49 we added 1209 and 1213, but didn't subtract any terms. Over the
weekend we started getting this error with the import task in the course
API:

```
rake aborted!
Errno::ENOMEM: Cannot allocate memory - fork(2)
/swadm/www/courses.umn.edu/releases/20191113213628/lib/tasks/json_import.rake:56:in `fork'
/swadm/www/courses.umn.edu/releases/20191113213628/lib/tasks/json_import.rake:56:in `block (4 levels) in <top (required)>'
/swadm/www/courses.umn.edu/releases/20191113213628/lib/tasks/json_import.rake:55:in `each'
/swadm/www/courses.umn.edu/releases/20191113213628/lib/tasks/json_import.rake:55:in `block (3 levels) in <top (required)>'
/swadm/www/courses.umn.edu/releases/20191113213628/lib/tasks/json_import.rake:54:in `each'
/swadm/www/courses.umn.edu/releases/20191113213628/lib/tasks/json_import.rake:54:in `each_slice'
/swadm/www/courses.umn.edu/releases/20191113213628/lib/tasks/json_import.rake:54:in `block (2 levels) in <top (required)>'
/swadm/www/courses.umn.edu/shared/bundle/ruby/2.3.0/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
Tasks: TOP => json_import:update_all => json_import:directory_import
```

Reducing the number of terms here to see if this helps.

Fixes #51.