### PR TITLE
Update Capistrano and its dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ source "https://artifactory.umn.edu/artifactory/api/gems/asr-rubygems" do
 
   group :development do
     gem 'bundler-audit'
-    gem 'capistrano', '= 3.3.5'
+    gem 'capistrano', '= 3.16.0'
     gem 'capistrano-bundler', '~> 1.1'
     gem 'lastpassify'
   end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,18 +7,19 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    airbrussh (1.4.0)
+      sshkit (>= 1.6.1, != 1.7.0)
     bundler-audit (0.7.0.1)
       bundler (>= 1.2.0, < 3)
       thor (>= 0.18, < 2)
-    capistrano (3.3.5)
-      capistrano-stats (~> 1.1.0)
+    capistrano (3.16.0)
+      airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
-      sshkit (~> 1.3)
+      sshkit (>= 1.9.0)
     capistrano-bundler (1.6.0)
       capistrano (~> 3.1)
-    capistrano-stats (1.1.1)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.8)
     daemon-kit (0.3.3)
       eventmachine (>= 0.12.10)
       thor
@@ -55,7 +56,7 @@ GEM
     rufus-scheduler (2.0.24)
       tzinfo (>= 0.3.22)
     safely (0.3.2)
-    sshkit (1.21.0)
+    sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     thor (1.0.1)
@@ -70,7 +71,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 6.0)!
   bundler-audit!
-  capistrano (= 3.3.5)!
+  capistrano!
   capistrano-bundler (~> 1.1)!
   daemon-kit!
   i18n (~> 0.8)!
@@ -81,6 +82,9 @@ DEPENDENCIES
   rspec (~> 3.2)!
   rufus-scheduler (~> 2.0)!
   safely!
+
+RUBY VERSION
+   ruby 2.7.1p83
 
 BUNDLED WITH
    2.1.4

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock '3.3.5'
+lock '3.16.0'
 
 set :application, 'peoplesoft_course_class_data'
 set :repo_url, 'https://github.com/umn-asr/peoplesoft_course_class_data'


### PR DESCRIPTION
Capistrano hasn't been updated in this application since it was first
added 6 years ago. Updating it as there are metrics capabilities in the
old version that we don't want to use.

The gem has to be locked to a specific version that is referenced in
config/deploy. Running the tests, all pass.