### PR TITLE
Update Capistrano in second part of Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 6.0)!
   bundler-audit!
-  capistrano!
+  capistrano (= 3.16.0)!
   capistrano-bundler (~> 1.1)!
   daemon-kit!
   i18n (~> 0.8)!


### PR DESCRIPTION
Unsure how this was missed in #57, as the first part of the Gemfile.lock
did capture the version change. Updating here will hopefully fix deploy
issues we are seeing.