### PR TITLE
Update deploy config for new servers

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,9 +1,9 @@
-role :app, %w{asr-courses-prd-web-02.oit.umn.edu}
+role :app, %w{asr-courses-prd-web-03.oit.umn.edu}
 
 # Configuration
-set :server, 'asr-courses-prd-web-02.oit.umn.edu'
+set :server, 'asr-courses-prd-web-03.oit.umn.edu'
 
-server 'asr-courses-prd-web-02.oit.umn.edu',
+server 'asr-courses-prd-web-03.oit.umn.edu',
   roles: fetch(:roles),
   ssh_options: {
     user: fetch(:user),

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,9 +1,9 @@
-role :app, %w{asr-courses-qat-web-02.oit.umn.edu}
+role :app, %w{asr-courses-qat-web-03.oit.umn.edu}
 
 # Configuration
-set :server, 'asr-courses-qat-web-02.oit.umn.edu'
+set :server, 'asr-courses-qat-web-03.oit.umn.edu'
 
-server 'asr-courses-qat-web-02.oit.umn.edu',
+server 'asr-courses-qat-web-03.oit.umn.edu',
   roles: fetch(:roles),
   ssh_options: {
     user: fetch(:user),


### PR DESCRIPTION
Same as https://github.com/umn-asr/courses/pull/200

Peoplesoft Course Class Data has been deployed to both of the new
servers succesfully.

The DNS change hasn't happened yet, but since the Ruby version was
updated awhile ago, the repo has also not been deployable to the old
servers for awhile.

Updating the servers in the deploy config now in preparation for the DNS
change, and so that it is less to remember in every new branch.