### PR TITLE
Create production Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 .bundle
 .cache/
 .dockerignore
+.env*
 .git/
 .gitconfig
 .gitignore

--- a/.env.production.erb
+++ b/.env.production.erb
@@ -1,0 +1,3 @@
+INTEGRATION_BROKER_PASSWORD="<%= `lpass show --password 'Shared-Applications/courses/integration_broker_production'`.chomp %>"
+INTEGRATION_BROKER_URL="<%= `lpass show --field='Hostname' 'Shared-Applications/courses/integration_broker_production'`.chomp %>"
+INTEGRATION_BROKER_USER="<%= `lpass show --username 'Shared-Applications/courses/integration_broker_production'`.chomp %>"

--- a/.env.staging.erb
+++ b/.env.staging.erb
@@ -1,0 +1,3 @@
+INTEGRATION_BROKER_PASSWORD="<%= `lpass show --password 'Shared-Applications/courses/integration_broker_staging'`.chomp %>"
+INTEGRATION_BROKER_URL="<%= `lpass show --field='Hostname' 'Shared-Applications/courses/integration_broker_staging'`.chomp %>"
+INTEGRATION_BROKER_USER="<%= `lpass show --username 'Shared-Applications/courses/integration_broker_staging'`.chomp %>"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ tmp/*
 .bash_history
 .cache/
 .capistrano/*
+.env.production
+.env.staging
 .gitconfig
 .irb_history
 .local/*

--- a/config/credentials.rb
+++ b/config/credentials.rb
@@ -2,7 +2,7 @@ require "yaml"
 
 module PeoplesoftCourseClassData
   module Config
-    credentials = YAML.load_file("config/credentials.yml")
+    credentials = YAML.load_file("#{DAEMON_ROOT}/config/credentials.yml")
 
     CREDENTIALS = {
       dev: {

--- a/config/credentials.yml.erb
+++ b/config/credentials.yml.erb
@@ -1,0 +1,17 @@
+---
+dev:
+  endpoint: <%= ENV["INTEGRATION_BROKER_URL"] %>
+  username: <%= ENV["INTEGRATION_BROKER_USER"] %>
+  password: <%= ENV["INTEGRATION_BROKER_PASSWORD"] %>
+test:
+  endpoint: <%= ENV["INTEGRATION_BROKER_URL"] %>
+  username: <%= ENV["INTEGRATION_BROKER_USER"] %>
+  password: <%= ENV["INTEGRATION_BROKER_PASSWORD"] %>
+qat:
+  endpoint: <%= ENV["INTEGRATION_BROKER_URL"] %>
+  username: <%= ENV["INTEGRATION_BROKER_USER"] %>
+  password: <%= ENV["INTEGRATION_BROKER_PASSWORD"] %>
+production:
+  endpoint: <%= ENV["INTEGRATION_BROKER_URL"] %>
+  username: <%= ENV["INTEGRATION_BROKER_USER"] %>
+  password: <%= ENV["INTEGRATION_BROKER_PASSWORD"] %>

--- a/config/msmtprc.erb
+++ b/config/msmtprc.erb
@@ -1,0 +1,12 @@
+<% env = ENV.fetch("ENVIRONMENT", "unknown") %>
+# configuration file for msmtp
+# https://marlam.de/msmtp/
+
+account default
+host smtp.umn.edu
+port 587
+tls on
+tls_starttls on
+auth off
+from "PeopleSoft Course Class Data [<%= env %>] <do-not-reply@peoplesoft-course-class-data-<%= env %>.umn.edu>"
+set_from_header on

--- a/script/_populate_env
+++ b/script/_populate_env
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+# script/_populate_env: Populate the environment variables
+
+ENVIRONMENT=$1
+
+ENV_FILE=".env.${ENVIRONMENT}"
+ERB_FILE="${ENV_FILE}.erb"
+
+# exit if the environment specified doesn't exist
+if [ ! -f $ERB_FILE ]; then
+  echo "ERROR: Invalid environment: '$ENVIRONMENT'"
+  exit 1
+fi
+
+# prompt to overwrite if the .env file already exists
+if [ -f "$ENV_FILE" ]; then
+  read -p  "The file '$ENV_FILE' already exists. Do you want to overwrite? (y/n) " -r
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+      exit 0
+  fi
+fi
+
+# login to LastPass if necessary
+if [[ ! $(lpass status) == "Logged in"* ]]; then
+  lpass login $LASTPASS_USERNAME@umn.edu
+fi
+
+# populate the environment file
+erb "${ERB_FILE}" > "${ENV_FILE}"

--- a/script/_prod_entrypoint
+++ b/script/_prod_entrypoint
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# populate the secrets
+echo "==> Populating the application secrets for '${ENVIRONMENT}'"
+erb "config/credentials.yml.erb" > "config/credentials.yml"
+
+# configure msmtp
+erb "config/msmtprc.erb" > "${HOME}/.msmtprc"
+
+echo "==> Started PeopleSoft Course Class Data"
+echo "==> Using endpoint: '${INTEGRATION_BROKER_URL}'"
+exec "$@"

--- a/script/prod_build
+++ b/script/prod_build
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+export APP_NAME="$(basename $(pwd))"
+export PUSH_IMAGE=false
+export SCRIPT=$(basename -- $0)
+
+export MODIFIED_INDICATOR="$(git diff --quiet || echo '-modified')"
+export GIT_COMMIT="$(git rev-parse HEAD)$MODIFIED_INDICATOR"
+
+export DOCKER_REPO_HOSTNAME="asr-docker-local.artifactory.umn.edu"
+export IMAGE_TAG_WITH_GIT_COMMIT="$DOCKER_REPO_HOSTNAME/$APP_NAME:$GIT_COMMIT"
+export IMAGE_TAG_LATEST="$DOCKER_REPO_HOSTNAME/$APP_NAME:latest"
+
+while test $# -gt 0; do
+  case "$1" in
+    -h|--help)
+      echo "$SCRIPT - build the production docker image"
+      echo " "
+      echo "$SCRIPT [options] application [arguments]"
+      echo " "
+      echo "options:"
+      echo "-h, --help                show this help message"
+      echo "-p, --push                push the image to Artifactory"
+      exit 0
+      ;;
+    -p|--push)
+      PUSH_IMAGE=true
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+# build the docker image
+docker build \
+  --build-arg="GIT_COMMIT=$GIT_COMMIT" \
+  --target production \
+  -t "$IMAGE_TAG_WITH_GIT_COMMIT" \
+  -t "$IMAGE_TAG_LATEST" \
+  .
+
+# push the image if the '--push' flag is set
+if [ "$PUSH_IMAGE" = true ]; then
+
+  # abort if the Git working tree is modified
+  if [ -n "$MODIFIED_INDICATOR" ]; then
+    echo -e '\033[31mERROR:\033[0m Unable to push image when working tree is modified!'
+    exit 1
+  fi
+
+  docker push "$IMAGE_TAG_WITH_GIT_COMMIT"
+  docker push "$IMAGE_TAG_LATEST"
+fi

--- a/script/prod_run
+++ b/script/prod_run
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+CONTAINER_NAME="$(basename $(pwd))"
+DOCKER_REPO_HOSTNAME="asr-docker-local.artifactory.umn.edu"
+IMAGE_NAME="$DOCKER_REPO_HOSTNAME/$CONTAINER_NAME:latest"
+
+if [ $# -eq 0 ]; then
+  echo "Provide an environment: script/prod_run [production|staging]"
+  exit 1
+fi
+
+ENVIRONMENT=$1
+echo "==> Populating environment variables for '${ENVIRONMENT}'..."
+
+docker run \
+  -it --rm --pull=always \
+  -e LASTPASS_USERNAME=$(whoami) \
+  -v "$(pwd):/workdir" \
+  asrcustomsolutions/lastpass:latest \
+  ./script/_populate_env "$ENVIRONMENT"
+
+echo "==> Building container for ${IMAGE_NAME}"
+./script/prod_build
+
+echo "==> Running container for ${IMAGE_NAME}"
+source ".env.${ENVIRONMENT}"
+
+docker run \
+  --rm \
+  --name "${CONTAINER_NAME}" \
+  --env DAEMON_ENV="${ENVIRONMENT}" \
+  --env ENVIRONMENT="${ENVIRONMENT}" \
+  --env INTEGRATION_BROKER_PASSWORD="${INTEGRATION_BROKER_PASSWORD}" \
+  --env INTEGRATION_BROKER_URL="${INTEGRATION_BROKER_URL}" \
+  --env INTEGRATION_BROKER_USER="${INTEGRATION_BROKER_USER}" \
+  "$IMAGE_NAME"


### PR DESCRIPTION
This PR adds the `production` target to our Dockerfile and adds the standard Docker scripts to build that target. It also includes a `script/prod_run` script that can be used to start a staging or production container locally. This was needed to test the changes to our production Dockerfile, so we include it in this PR.

The default command for the production container is `bin/peoplesoft_course_class_data`. This mostly works, but I cannot figure out how to get DaemonKit to log properly to STDOUT. I am seeing errors when I stop the container: `log writing failed. can't be called from trap context`. I suspect this issue has something to do with DaemonKit being a very old dependency and unmaintained. That said, my intention is to replace the existing `daemon-kit` and `rufus-scheduler` gems with the `whenever` gem, so I think we can just ignore this issue for the time being.

Some notable items:

* Secrets are populated as part of the `script/_prod_entrypoint` entrypoint. Populating secrets as part of the main entrypoint allows us to us to run things like `kamal app exec bash` without specifying the `--reuse` flag to ensure a proper database connection.

* The `Dockerfile` has been modified to work for both development and production environments. It tags the various stages of the Docker multi-stage build so that they can leveraged using the [Docker target option](https://docs.docker.com/reference/cli/docker/buildx/build/#target).

* Cron was added to the Dockerfile because we will be integrating the `whenever` gem in the near future.

* We are installing and configuring [msmtp](https://marlam.de/msmtp/msmtp.html) to handle mail requests from cron. The `Dockerfile` was modified to install both `msmtp` and `msmtp-mta` (which symlinks `sendmail` to `msmtp`). Also, a `~/.msmtprc` file gets created when the application starts so that `msmtp` know what configuration values to use (SMTP server host, port, from address, etc). We chose to create the `~/.msmtprc` file at application start instead of when the Dockerfile is built because that way we can inject the `$ENVIRONMENT` environment variable into the from address.