### PR TITLE
Upgrade to Ruby v3.2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION="3.1.6"
+ARG RUBY_VERSION="3.2.5"
 
 ### base ###
 FROM ruby:$RUBY_VERSION-slim AS base

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://artifactory.umn.edu/artifactory/api/gems/asr-rubygems" do
-  ruby "~> 3.1"
+  ruby "~> 3.2"
 
   gem "activesupport", "~> 6.1"
   gem "i18n", "~> 1.14"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ DEPENDENCIES
   whenever!
 
 RUBY VERSION
-   ruby 3.1.6p260
+   ruby 3.2.5p208
 
 BUNDLED WITH
-   2.3.27
+   2.4.19


### PR DESCRIPTION
Now that DaemonKit has been removed from the project, we can use versions of Ruby above v3.1.x. This PR upgrades the project to use the latest version of Ruby v3.2.