### PR TITLE
Update Cron email

### DIFF
--- a/config/msmtprc.erb
+++ b/config/msmtprc.erb
@@ -8,5 +8,5 @@ port 587
 tls on
 tls_starttls on
 auth off
-from "PeopleSoft Course Class Data [<%= env %>] <do-not-reply@peoplesoft-course-class-data-<%= env %>.umn.edu>"
+from "PeopleSoft Course Class Data [<%= env %>] <asrwebteam@umn.edu>"
 set_from_header on

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,6 @@
 env :BUNDLE_APP_CONFIG, ENV["BUNDLE_APP_CONFIG"]
 env :HOME, ENV["HOME"]
-env :MAILTO, "asr-web-errors@lists.umn.edu"
+env :MAILTO, "asrwebteam@umn.edu"
 env :PS_ENV, ENV["PS_ENV"]
 env :TMP_DIR_JSON, "#{ENV["HOME"]}/json_tmp"
 env :TMP_DIR_XML, "#{ENV["HOME"]}/tmp"


### PR DESCRIPTION
This PR updates the to/from email address used by Cron to ensure failure messages do not end up in the spam folder. Recent changes by the HEAT team have made it so we need to use valid to/from addresses going forward.